### PR TITLE
Добавлен метод принудительного обновления адреса загрузки

### DIFF
--- a/YandexAPI.php
+++ b/YandexAPI.php
@@ -212,5 +212,16 @@ class YandexAPI
         return false;
     }
 
+    /**
+     * Принудительное обновление ссылки для загрузки
+     *
+     * @return bool|string
+     */
+    public function updateLinkUrl()
+    {
+        $this->link_url = null;
+        return $this->getLink();
+    }
+
 
 }


### PR DESCRIPTION
Когда нужно добавить старый сайт в Турбо - мы генерируем несколько xml.
Потом их отправляем по API. Но пока отправится сотый файл, адрес загрузки уже становится неактуальным и есть необходимость обновлять его.